### PR TITLE
allow more flexible parent paths

### DIFF
--- a/lib/require-linked-peer.js
+++ b/lib/require-linked-peer.js
@@ -4,7 +4,7 @@ var path = require('path');
 
 module.exports = function (r) {
   for (var parent = module.parent; parent; parent = parent.parent) {
-    if (parent.paths && parent.paths.length && parent.paths[0] === path.join(process.cwd(), 'node_modules')) {
+    if (parent.paths && parent.paths.length && parent.paths.indexOf(path.join(process.cwd(), 'node_modules')) !== -1) {
       return parent.require(r);
     }
   }


### PR DESCRIPTION
The change allows you the following:
##### /proj-a/module.js

``` js
var requireLink = require('require-linked-peer')
var mobuleB = requireLink('module-from-b')
```

(_The usual usage for require-linked-peer_)
##### The parent can have a more flexible structure

```
/proj-b/node_modules/mobule-from-b
/proj-b/some/deep/folder/index.js
```
##### /proj-b/some/deep/folder/index.js

``` js
var moduleFromA = require('proj-a')
// do something
```

```
cd /proj-b
node ./some/deep/folder/index.js
```

The change was needed because when running the above, **require-linked-peer** would throw an error saying it doesn't find **module-from-b**
